### PR TITLE
It kinda works — can't dismiss by clicking

### DIFF
--- a/src/TextAnnotator.jsx
+++ b/src/TextAnnotator.jsx
@@ -188,16 +188,15 @@ export default class TextAnnotator extends Component {
 
   /** Common handler for annotation CREATE or UPDATE **/
   onCreateOrUpdateAnnotation = method => (annotation, previous) => {
-    this.clearState();
+    const updatedAnnotation = annotation.clone();
+    this.highlighter.addOrUpdateAnnotation(updatedAnnotation, previous);
 
-    this.selectionHandler.clearSelection();
-    this.highlighter.addOrUpdateAnnotation(annotation, previous);
+    this.props[method](updatedAnnotation, previous ? previous.clone() : null);
 
-    // Call CREATE or UPDATE handler
-    if (previous)
-      this.props[method](annotation.clone(), previous.clone());
-    else
-      this.props[method](annotation.clone(), this.overrideAnnotationId(annotation));
+    this.setState({
+      selectedAnnotation: updatedAnnotation,
+      selectedDOMElement: this.highlighter.findAnnotationSpans(updatedAnnotation)[0]
+    });
   }
 
   onDeleteAnnotation = annotation => {
@@ -384,10 +383,10 @@ export default class TextAnnotator extends Component {
         { this.state.selectedAnnotation &&
           <Editor
             ref={this._editor}
-            autoPosition={this.props.config.editorAutoPosition}
-            wrapperEl={this.props.wrapperEl}
             annotation={this.state.selectedAnnotation}
             selectedElement={this.state.selectedDOMElement}
+            autoPosition={this.props.config.editorAutoPosition}
+            wrapperEl={this.props.wrapperEl}
             readOnly={readOnly}
             allowEmpty={this.props.config.allowEmpty}
             widgets={this.state.widgets}
@@ -398,7 +397,6 @@ export default class TextAnnotator extends Component {
             onAnnotationDeleted={this.onDeleteAnnotation}
             onCancel={this.onCancelAnnotation} />
         }
-
         { this.state.selectedRelation &&
           <RelationEditor
             relation={this.state.selectedRelation}


### PR DESCRIPTION
I was testing [Cody](https://sourcegraph.com/cody). I installed it, cloned the Recogito repository, moved the code for the external dependency recogito-core into the the codebase from node_modules, and had a conversation about keeping the editor open.

After a few attempts, it came up with this, which mostly works. The only remaining problem is that after adding a new comment, clicking outside the dialog doesn't dismiss it. Clicking "Cancel" still works to dismiss it, and clicking outside the dialog before adding a new comment still works to dismiss it.

My main takeaway: I have no idea how this codebase works, and I was able to get it to do something. I'm sure the solution is awful, and someone who knows what they're doing could do it with far less pollution of the codebase. I think I'm starting to understand the allure of abusing Ask for students. I was literally _only_ asking questions and then clicking "Apply", I didn't type _any_ code myself

These tools are going to result in so much technical debt. But on the other hand, they will also result in a lot of things getting built that otherwise would not have gotten built, which has kinda been our raison d'être since the very beginning.